### PR TITLE
Fix the default depth value in the phone-numbers command

### DIFF
--- a/recount_code_screen/main.py
+++ b/recount_code_screen/main.py
@@ -14,7 +14,7 @@ def crawl():
 
 @crawl.command()
 @click.argument("url")
-@click.option("--depth", default=1, help="Desired tree depth to crawl to. By default only scrapes the given URL")
+@click.option("--depth", default=None, help="Desired tree depth to crawl to. By default only scrapes the given URL")
 def phone_numbers(url: str, depth: str):
     crawler = PhoneNumberCrawler(url=url, depth=int(depth) if depth else None)
     click.echo("Crawling for phone numbers...")


### PR DESCRIPTION
Fixes #2 

I noticed at the last minute that the default value of the `--depth` option `crawl phone-numbers` had an old test value and I didn't get a chance to correct it before submitting.

In the interest of fair play, I made the change on this branch, so as not to taint `main` by working past the time limit. But also I needed to fix it because it was gonna drive me nuts without at least opening a PR with the fix.